### PR TITLE
[Feature] AudioManager, ButtonListener

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,10 +1,11 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
+    id 'kotlin-kapt'
 }
 
 android {
-    compileSdk 30
+    compileSdk 31
 
     defaultConfig {
         applicationId "com.example.check_in_speaker"
@@ -29,6 +30,9 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    viewBinding {
+        enabled = true
+    }
 }
 
 dependencies {
@@ -40,4 +44,17 @@ dependencies {
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+
+
+    // Euphony
+    implementation 'euphony.lib:euphony:0.7.1.6'
+
+    // Coroutine
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
+
+    // ViewModel
+    def lifecycle_version = "2.4.0-beta01"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+    // LiveData
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
 }

--- a/app/src/main/java/com/example/check_in_speaker/MainActivity.kt
+++ b/app/src/main/java/com/example/check_in_speaker/MainActivity.kt
@@ -1,11 +1,147 @@
 package com.example.check_in_speaker
 
-import androidx.appcompat.app.AppCompatActivity
+import android.annotation.SuppressLint
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.os.Build
 import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelProvider
+import com.example.check_in_speaker.databinding.ActivityMainBinding
+import com.example.check_in_speaker.viewmodel.MainViewModel
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(){
+
+    private lateinit var binding: ActivityMainBinding
+    private lateinit var mainViewModel: MainViewModel
+    private lateinit var audioFocusRequest: AudioFocusRequest
+    private lateinit var audioManager: AudioManager
+
+    private var isClicked : Boolean = false
+    private var initVolume = 0
+    private var safeNumber = "hello"
+    private var audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
+        if(focusChange == AudioManager.AUDIOFOCUS_GAIN || focusChange == AudioManager.AUDIOFOCUS_LOSS) {
+            if(!isClicked) {
+                buttonVisibility(isClicked)
+                mainViewModel.onClickCheckInButton()
+                setInitVolume()
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        val view = binding.root
+        setContentView(view)
+
+        mainViewModel = ViewModelProvider(this)[MainViewModel::class.java]
+        initAudioManager()
+
+        mainViewModel.isClickCheckInButton.observe(this) {
+            isClicked = it
+        }
+
+        binding.btnMainCheckin.setOnClickListener {
+            clickCheckIn()
+        }
+    }
+
+    private fun initAudioManager() {
+        audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        initVolume = audioManager.getStreamVolume(
+            AudioManager.STREAM_MUSIC
+        )
+
+        initAudioFocusRequest()
+    }
+
+    private fun initAudioFocusRequest() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioFocusRequest = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN).run {
+                setAudioAttributes(AudioAttributes.Builder().run {
+                    setUsage(AudioAttributes.USAGE_MEDIA)
+                    setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                    build()
+                })
+                setWillPauseWhenDucked(true)
+                setAcceptsDelayedFocusGain(true)
+                setOnAudioFocusChangeListener(audioFocusChangeListener)
+                build()
+            }
+        }
+    }
+
+    private fun clickCheckIn() {
+        if (isClicked) {
+            setAudioFocusRequest()
+        } else {
+            setInitVolume()
+        }
+
+        buttonVisibility(isClicked)
+        mainViewModel.onClickCheckInButton()
+    }
+
+    /**
+     * TODO Modify 'safeNumber' (change SharedPreference value)
+     */
+    @SuppressLint("NewApi")
+    private fun setAudioFocusRequest() {
+        when(audioManager.requestAudioFocus(audioFocusRequest)) {
+            AudioManager.AUDIOFOCUS_REQUEST_GRANTED -> {
+                setCheckInVolume()
+                mainViewModel.focusStatusIsGranted(safeNumber)
+            }
+            AudioManager.AUDIOFOCUS_REQUEST_FAILED -> {
+                return
+            }
+        }
+    }
+
+    private fun setCheckInVolume() {
+        audioManager.setStreamVolume(
+            AudioManager.STREAM_MUSIC,
+            audioManager.getStreamMaxVolume(((AudioManager.STREAM_MUSIC * 0.90).toInt())),
+            AudioManager.FLAG_PLAY_SOUND
+        )
+    }
+
+    private fun setInitVolume() {
+        audioManager.setStreamVolume(
+            AudioManager.STREAM_MUSIC,
+            initVolume,
+            AudioManager.FLAG_PLAY_SOUND
+        )
+
+        mainViewModel.focusStatusIsFailed()
+    }
+
+    private fun buttonVisibility(isClick : Boolean) {
+        if(isClick) {
+            binding.progressBarMainCheckin.visibility = View.VISIBLE
+            binding.btnMainCheckin.text = "체크인 종료"
+        } else {
+            binding.progressBarMainCheckin.visibility = View.INVISIBLE
+            binding.btnMainCheckin.text = "체크인 시작"
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        if(!isClicked) {
+            buttonVisibility(isClicked)
+            mainViewModel.onClickCheckInButton()
+        }
+        setInitVolume()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        setInitVolume()
     }
 }

--- a/app/src/main/java/com/example/check_in_speaker/MainActivity.kt
+++ b/app/src/main/java/com/example/check_in_speaker/MainActivity.kt
@@ -137,11 +137,27 @@ class MainActivity : AppCompatActivity(){
             buttonVisibility(isClicked)
             mainViewModel.onClickCheckInButton()
         }
-        setInitVolume()
+        setVolumePauseAndDestroy()
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        setInitVolume()
+        setVolumePauseAndDestroy()
+    }
+
+    private fun isVolumeSameInitVolume() : Boolean {
+        val nowVolume = audioManager.getStreamVolume(
+            AudioManager.STREAM_MUSIC
+        )
+
+        return initVolume == nowVolume
+    }
+
+    private fun setVolumePauseAndDestroy() {
+        if(!isVolumeSameInitVolume()) {
+            setInitVolume()
+        } else {
+            mainViewModel.focusStatusIsFailed()
+        }
     }
 }

--- a/app/src/main/java/com/example/check_in_speaker/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/check_in_speaker/viewmodel/MainViewModel.kt
@@ -1,0 +1,31 @@
+package com.example.check_in_speaker.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import euphony.lib.transmitter.EuTxManager
+
+class MainViewModel : ViewModel() {
+
+    private var _isClickCheckInButton = MutableLiveData(true)
+    val isClickCheckInButton : LiveData<Boolean>
+        get() = _isClickCheckInButton
+    private val mTxManager: EuTxManager by lazy {
+        EuTxManager()
+    }
+
+    fun onClickCheckInButton() {
+        _isClickCheckInButton.value = _isClickCheckInButton.value != true
+    }
+
+    fun focusStatusIsFailed() {
+        mTxManager.stop()
+    }
+
+    fun focusStatusIsGranted(safeNumber : String) {
+        mTxManager.euInitTransmit(safeNumber)
+        mTxManager.process(-1)
+    }
+
+
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -84,11 +84,11 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:max="100"
-        app:layout_constraintTop_toBottomOf="@+id/linearLayout_main_info"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toTopOf="@+id/btn_main_checkin"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/btn_main_checkin"
-        />
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout_main_info" />
 
     <Button
         android:id="@+id/btn_main_checkin"


### PR DESCRIPTION
### **체크인 버튼 눌렀을 때 음파 송신 시작/종료를 제어(누르기 전 / 후)**
<img src ="https://user-images.githubusercontent.com/42669772/135306637-c3da968a-d506-44db-a403-937f48a22597.jpg" width="35%"/> <img src ="https://user-images.githubusercontent.com/42669772/135306642-9c2fb55f-419a-4b97-9b86-c8d78b701e7d.jpg" width="35%"/>
<br>
<br>
<br>

### **체크인 시작/종료에 따라 소리 크기 조절 (AudioManager)**
<img src ="https://user-images.githubusercontent.com/42669772/135307102-4030f909-8e58-43ea-a1f3-44ebb1a95736.jpg" width="25%"/><img src ="https://user-images.githubusercontent.com/42669772/135307107-efe186f8-ac31-4dd5-a7c5-8abf20fea39f.jpg" width="25%"/><img src ="https://user-images.githubusercontent.com/42669772/135307106-6f643879-95c5-4921-9d32-a3df2a1b0fec.jpg" width="25%"/>

**처음 앱을 실행했을 때 미디어 볼륨 값을 저장한 후, 음파 송신 시 미디어 크기를 최대로 키우고 음파 종료 시에 처음 미디어 볼륨 값으로 돌려 놓습니다.** 

<br>
<br>
<br>

### **오디오 포커싱 (AudioManager)**
<img src ="https://user-images.githubusercontent.com/42669772/135307763-3d35f4ca-3a28-4d3a-9d47-fcea734d7443.jpg" width="35%"/> <img src ="https://user-images.githubusercontent.com/42669772/135307769-48bee209-1f19-4ccc-af32-58d628372106.jpg" width="35%"/>

**첫 번째 사진은 음악을 듣던 중 음파 송신을 하게 되면 앱에서 AudioFocus를 가져와서 음악을 중지 시킵니다.
두 번째 사진은 음파 송신 중에 음악을 실행하거나, 전화가 오는 등 앱의 AudioFocus를 뺏기게 되는 경우 송신을 중단 시킵니다.**
<br>
<br>

+) ViewModel에 `AudioManager` 같은 것도 넣어보려고 했는데 검색하다보니 ViewModel에 Activity나 Context를 참조하는 클래스? 같은게 있으면 좋지 않다는 것을 봐서 일단 MainActivity에서 선언해두었습니다. (https://stackoverflow.com/questions/51451819/how-to-get-context-in-android-mvvm-viewmodel)
ViewModel을 처음 써봐서 추가적으로 수정할 부분에 대해서 말씀해주시면 적극 반영해서 수정하겠습니다!