### PR TITLE
메인 화면에서 뒤로 가기 버튼을 두 번 눌렀을 때 앱이 종료되는 로직 적용

### DIFF
--- a/app/src/main/java/com/example/check_in_speaker/MainActivity.kt
+++ b/app/src/main/java/com/example/check_in_speaker/MainActivity.kt
@@ -324,6 +324,17 @@ class MainActivity : AppCompatActivity(){
         }
     }
 
+    private var backPressedTime: Long = 0
+
+    override fun onBackPressed() {
+        if(System.currentTimeMillis() - backPressedTime > 2000){
+            backPressedTime = System.currentTimeMillis()
+            Toast.makeText(this, "뒤로 가기 버튼을 한 번 더 누르면 종료됩니다.", Toast.LENGTH_SHORT).show()
+        }else{
+            super.onBackPressed()
+        }
+    }
+
     companion object {
         const val PERMISSION_REQUEST_CODE = 2021
     }


### PR DESCRIPTION
## 업데이트 내용
기존에는 뒤로 가기 버튼을 한 번만 눌러도 앱이 종료되었습니다.
송신 도중 뒤로 가기 버튼을 실수로 눌렀을 때 앱이 종료되지 않도록 다음과 같은 기능을 추가했습니다.

## 결과
<img width="341" alt="스크린샷 2021-10-26 오후 11 51 51" src="https://user-images.githubusercontent.com/35393459/138904624-bc29ac60-5111-42cf-9f6f-6517edf10782.png">
